### PR TITLE
docs: add guides for options and datatype extensions

### DIFF
--- a/docs/03_REFERENCES.md
+++ b/docs/03_REFERENCES.md
@@ -84,6 +84,13 @@ flowchart LR
 | Modul-Uebersicht | `../src/FileTypeDetection/README.md` |
 | Unterordner-Details | `../src/FileTypeDetection/Detection/README.md`, `../src/FileTypeDetection/Infrastructure/README.md`, `../src/FileTypeDetection/Configuration/README.md`, `../src/FileTypeDetection/Abstractions/README.md`, `../src/FileTypeDetection/Abstractions/Detection/README.md`, `../src/FileTypeDetection/Abstractions/Archive/README.md`, `../src/FileTypeDetection/Abstractions/Hashing/README.md`, `../src/FileClassifier.App/README.md` |
 
+## 6.1 Change Playbooks
+| Thema | Guide |
+|---|---|
+| Optionen anlegen/anpassen | `guides/OPTIONS_CHANGE_GUIDE.md` |
+| Neue Datatypes/API-Modelle erweitern | `guides/DATATYPE_EXTENSION_GUIDE.md` |
+| Guide-Index | `guides/README.md` |
+
 ## 7. Verifikationsreferenzen
 Empfohlene Freigabe-Checks:
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,14 @@ Diese Doku ist in drei Ebenen getrennt:
 5. [test-matrix-hashing.md](./test-matrix-hashing.md)
 6. [PRODUCTION_READINESS_CHECKLIST.md](./PRODUCTION_READINESS_CHECKLIST.md)
 7. [DIN_SPECIFICATION_DE.md](./DIN_SPECIFICATION_DE.md)
+8. [guides/README.md](./guides/README.md)
 
-## 2.1 Vertiefende Implementierungsquellen
+## 2.1 Change Playbooks (neu)
+- [Guides Index](./guides/README.md)
+- [Playbook: Options anlegen und anpassen](./guides/OPTIONS_CHANGE_GUIDE.md)
+- [Playbook: Neue Datatypes und API-Modelle erweitern](./guides/DATATYPE_EXTENSION_GUIDE.md)
+
+## 2.2 Vertiefende Implementierungsquellen
 - [../src/FileTypeDetection/Detection/README.md](../src/FileTypeDetection/Detection/README.md)
 - [../src/FileTypeDetection/Infrastructure/README.md](../src/FileTypeDetection/Infrastructure/README.md)
 - [../src/FileTypeDetection/Configuration/README.md](../src/FileTypeDetection/Configuration/README.md)

--- a/docs/guides/DATATYPE_EXTENSION_GUIDE.md
+++ b/docs/guides/DATATYPE_EXTENSION_GUIDE.md
@@ -1,0 +1,121 @@
+# Playbook: Neue Datatypes und API-Modelle erweitern
+
+## 1. Zweck und Entscheidungsmatrix
+Dieses Playbook deckt zwei Aenderungsarten ab:
+1. neue erkennbare Formate ueber `FileKind` + `FileTypeRegistry`
+2. neue API-Modelle unter `Abstractions/*`
+
+| Vorhaben | Pfad |
+|---|---|
+| Neuer Dateityp (z. B. neue Magic-Signatur) | Abschnitt 2 |
+| Neues Rueckgabemodell fuer Public API | Abschnitt 3 |
+| Neues Format plus neues Modell | Abschnitte 2 und 3 in Kombination |
+
+## 2. Neue `FileKind`-Formate: zentrale Stellen
+### 2.1 Pflichtdateien
+| Bereich | Datei | Aufgabe |
+|---|---|---|
+| Oeffentliche Typliste | [`../../src/FileTypeDetection/Abstractions/Detection/FileKind.vb`](../../src/FileTypeDetection/Abstractions/Detection/FileKind.vb) | Enum-Wert ergaenzen |
+| SSOT Metadaten und Magic | [`../../src/FileTypeDetection/Detection/FileTypeRegistry.vb`](../../src/FileTypeDetection/Detection/FileTypeRegistry.vb) | Extension/Alias/Magic und Resolve-Verhalten |
+| Detection-Details | [`../../src/FileTypeDetection/Detection/README.md`](../../src/FileTypeDetection/Detection/README.md) | fachliche Erklaerung nachziehen |
+
+### 2.2 Registry-Punkte, die geprueft werden muessen
+- `ExtensionOverrides` (nur falls CanonicalExtension vom Enum-Namen abweicht)
+- `AliasOverrides` (Legacy-/Kompatibilitaets-Aliase)
+- `BuildMagicPatternCatalog()` (Magic-Pattern Aufnahme)
+- `HasStructuredContainerDetection()` (falls neuer Typ strukturierte Verfeinerung braucht)
+- indirekte Auswirkungen auf `KindsWithoutDirectContentDetection()`
+
+### 2.3 Bei neuen Containerarten zusaetzlich
+- `src/FileTypeDetection/Infrastructure/*` pruefen, ob Gate/Extractor den Container bereits traegt.
+- Falls nein: Infrastrukturpfad erweitern und Security-Gates (Depth, Size, Traversal, Links) mitziehen.
+
+## 3. Neue API-Modelle (`Abstractions/*`): zentrale Stellen
+### 3.1 Pflichtdateien
+| Bereich | Datei | Aufgabe |
+|---|---|---|
+| Modellklasse/enum | `src/FileTypeDetection/Abstractions/*` | neuen Typ definieren |
+| Teilbereich README | `src/FileTypeDetection/Abstractions/*/README.md` | Typ in Index aufnehmen |
+| Gesamtindex Modelle | [`../../src/FileTypeDetection/Abstractions/README.md`](../../src/FileTypeDetection/Abstractions/README.md) | Referenzliste aktualisieren |
+| API-Katalog | [`../01_FUNCTIONS.md`](../01_FUNCTIONS.md) | neue/veraenderte Rueckgabemodelle eintragen |
+| Referenzen | [`../03_REFERENCES.md`](../03_REFERENCES.md) | Modell- und Pfadreferenzen aktualisieren |
+| Contract-Doku (falls relevant) | `../04_*.md` | nur bei Contract-relevanten Signatur-/Vertragsaenderungen |
+
+### 3.2 Modellregeln
+- Modelle bleiben immutable orientiert und ohne I/O-Logik.
+- `Unknown`/fail-closed Semantik darf nicht aufgeweicht werden.
+- Bestehende Consumer-Vertraege bleiben stabil oder werden als Breaking Change ausgewiesen.
+
+## 4. Aktivierung und Einlesen
+### 4.1 Flowchart (Code -> Runtime)
+```mermaid
+flowchart TD
+    A["Codeaenderung: FileKind and/or Abstractions"] --> B["Build/Test"]
+    B --> C["App/Tests starten neuen Prozess"]
+    C --> D["FileTypeRegistry Shared Sub New()"]
+    D --> E["BuildDefinitionsFromEnum()"]
+    E --> F["BuildAliasMap + BuildMagicRules"]
+    F --> G["Detect* Pipeline (ReadHeader -> DetectByMagic -> Resolve)"]
+    G --> H["Public Output: FileType/DetectionDetail oder neues Modell"]
+```
+
+### 4.2 Sequence (Detect-Pipeline mit Registry)
+```mermaid
+sequenceDiagram
+    participant Consumer
+    participant Detector as FileTypeDetector
+    participant Registry as FileTypeRegistry
+    participant Core as CoreInternals/OpenXmlRefiner
+
+    Consumer->>Detector: Detect(path or bytes)
+    Detector->>Registry: DetectByMagic(header)
+    Registry-->>Detector: FileKind
+    alt archive-like path
+        Detector->>Core: Archive gate/refinement
+        Core-->>Detector: refined kind or unknown
+    end
+    Detector->>Registry: Resolve(kind)
+    Registry-->>Detector: FileType
+    Detector-->>Consumer: FileType or DetectionDetail
+```
+
+## 5. Verbindliche Checklist und Done-Kriterien
+### 5.1 Implementierungs-Checklist
+- [ ] Neuer Enum-Wert in `FileKind.vb` angelegt (falls Format-Erweiterung).
+- [ ] Registry um Extension/Alias/Magic erweitert, ohne Alias-Konflikt.
+- [ ] Strukturierte Verfeinerung geprueft (`HasStructuredContainerDetection`) falls notwendig.
+- [ ] Bei neuer Containerlogik: `Infrastructure/*` und Security-Gates geprueft.
+- [ ] Tests fuer Resolve, Alias, Magic und fail-closed Verhalten aktualisiert.
+- [ ] Doku-Ebenen `docs/01_FUNCTIONS.md`, `docs/02_ARCHITECTURE_AND_FLOWS.md`, `docs/03_REFERENCES.md` aktualisiert.
+- [ ] Modul-READMEs unter `src/FileTypeDetection/*` angepasst.
+
+### 5.2 Done-Kriterien
+Eine Datatype-/Modellaenderung ist nur dann fertig, wenn:
+1. Enum/Registry/Patterns konsistent aufloesen.
+2. Kein mehrdeutiger Alias bestehende Typen ueberschreibt.
+3. fail-closed Verhalten bei ungueltigen Eingaben erhalten bleibt.
+4. Tests Regressionen fuer Detection und Mapping abdecken.
+5. Doku-Landkarte fuer Entwickler und Verwender aktualisiert ist.
+
+## 6. Verifikation (Kommandos)
+```bash
+python3 tools/check-markdown-links.py
+dotnet test tests/FileTypeDetectionLib.Tests/FileTypeDetectionLib.Tests.csproj --filter "FullyQualifiedName~FileTypeRegistryUnitTests|FullyQualifiedName~HeaderCoveragePolicyUnitTests" -v minimal
+```
+
+Bei Modell- oder Contract-Aenderungen zusaetzlich:
+```bash
+dotnet test tests/FileTypeDetectionLib.Tests/FileTypeDetectionLib.Tests.csproj --filter "FullyQualifiedName~DeterministicHashingApiContractUnitTests|FullyQualifiedName~DeterministicHashingIntegrationTests" -v minimal
+```
+
+## 7. Kompatibilitaets- und Breaking-Change-Hinweise
+| Aenderung | Risiko | Einordnung |
+|---|---|---|
+| Neuer `FileKind` ohne bestehende Signaturen zu aendern | meist additive Erweiterung | non-breaking, aber Test- und Doku-Pflicht |
+| Alias aendert bestehendes Mapping | bestehende Consumer koennen anderes Ergebnis sehen | potentiell breaking |
+| Oeffentliche Modellproperties entfernen/umbenennen | Binary/Source-Consumer brechen | breaking |
+| Contract-Dokument (`docs/04_*`) nicht aktualisiert trotz Surface-Aenderung | Drift zwischen Code und Doku/Tests | release-blocking fuer API-Governance |
+
+## 8. Nicht-Ziele
+- Keine stillen API-Surface-Aenderungen ohne Contract-Dokumentation.
+- Keine Sicherheitslockerung im Archivpfad ohne explizite Risikoentscheidung und Testnachweis.

--- a/docs/guides/OPTIONS_CHANGE_GUIDE.md
+++ b/docs/guides/OPTIONS_CHANGE_GUIDE.md
@@ -1,0 +1,120 @@
+# Playbook: Options anlegen und anpassen
+
+## 1. Zweck und Zielgruppe
+Dieses Playbook beschreibt den verbindlichen Ablauf fuer neue oder geaenderte Optionen in der FileTypeDetection-API.
+
+Zielgruppe:
+- Entwickler, die `FileTypeProjectOptions` oder `FileTypeOptions` erweitern
+- Reviewer, die Vollstaendigkeit und fail-closed Verhalten pruefen
+- Verwender, die verstehen wollen, wann Runtime-Konfiguration aktiv wird
+
+## 2. Zentral betroffene Stellen (Datei-Map)
+| Bereich | Datei | Muss angepasst werden bei |
+|---|---|---|
+| Option-Definition und Normalize | [`../../src/FileTypeDetection/Configuration/FileTypeProjectOptions.vb`](../../src/FileTypeDetection/Configuration/FileTypeProjectOptions.vb) | neue Property, Default, Normalisierungsregel |
+| JSON Load/Parse und Snapshot-Set | [`../../src/FileTypeDetection/FileTypeOptions.vb`](../../src/FileTypeDetection/FileTypeOptions.vb) | JSON key mapping, parse guard, `SetSnapshot` |
+| JSON Export | [`../../src/FileTypeDetection/FileTypeOptions.vb`](../../src/FileTypeDetection/FileTypeOptions.vb) | `GetOptions()` fuer Snapshot-Sicht |
+| Baseline-Werte | [`../../src/FileTypeDetection/Configuration/FileTypeProjectBaseline.vb`](../../src/FileTypeDetection/Configuration/FileTypeProjectBaseline.vb) | produktive Defaults (`ApplyDeterministicDefaults`) |
+| Unit Tests (Options) | [`../../tests/FileTypeDetectionLib.Tests/Unit/FileTypeOptionsFacadeUnitTests.cs`](../../tests/FileTypeDetectionLib.Tests/Unit/FileTypeOptionsFacadeUnitTests.cs) | parse/export/normalize behavior |
+| Unit Tests (Baseline) | [`../../tests/FileTypeDetectionLib.Tests/Unit/FileTypeProjectBaselineUnitTests.cs`](../../tests/FileTypeDetectionLib.Tests/Unit/FileTypeProjectBaselineUnitTests.cs) | Baseline-Defaultwerte |
+
+## 3. Aenderungstypen
+### 3.1 Neue Scalar Option
+Beispiel: `Integer`, `Long`, `Boolean`.
+1. Property in `FileTypeProjectOptions` anlegen (inkl. sinnvollem Default).
+2. `NormalizeInPlace()` um fail-closed Guard erweitern.
+3. Parse-Pfad in `FileTypeOptions.LoadOptions(json)` erweitern.
+4. Export in `FileTypeOptions.GetOptions()` ergaenzen.
+5. Baseline-Entscheidung in `FileTypeProjectBaseline` treffen und dokumentieren.
+6. Tests fuer gueltige und ungueltige Werte ergaenzen.
+
+### 3.2 Neue Nested Option
+Beispiel: Unterobjekt wie `DeterministicHash`.
+1. Objekt in `FileTypeProjectOptions` definieren/erweitern.
+2. Dedicated parse helper in `FileTypeOptions` nutzen oder erweitern.
+3. Objekt in `GetOptions()` vollstaendig serialisieren.
+4. `Normalize`/`Clone`-Pfade auf tiefe Kopie und Sanitizing pruefen.
+5. Tests fuer nested JSON + unbekannte Keys + invalid values.
+
+### 3.3 Anpassung von Defaults/Normalization
+1. Default-Wert in `FileTypeProjectOptions` und ggf. Baseline in `FileTypeProjectBaseline` konsistent halten.
+2. Unit-Tests auf neue Grenzwerte aktualisieren.
+3. Risikohinweis in Doku ergaenzen, falls strengere Limits zu mehr `Unknown`/`False` fuehren.
+
+## 4. Aktivierung zur Laufzeit
+### 4.1 Flowchart (Aktivierung und Einlesen)
+```mermaid
+flowchart TD
+    A["Consumer/Startup"] --> B["FileTypeProjectOptions.DefaultOptions()"]
+    A --> C["FileTypeProjectBaseline.ApplyDeterministicDefaults() (optional)"]
+    A --> D["FileTypeOptions.LoadOptions(json) (optional)"]
+
+    B --> E["Snapshot-Bildung"]
+    C --> E
+    D --> E
+    E --> F["FileTypeOptions.SetSnapshot(...)"]
+    F --> G["Globale aktive Optionen"]
+
+    G --> H["FileTypeDetector / ArchiveProcessing / FileMaterializer / DeterministicHashing"]
+    H --> I["pro Aufruf: FileTypeOptions.GetSnapshot()"]
+    I --> J["Runtime-Entscheidung mit aktivem Snapshot"]
+```
+
+### 4.2 Sequence (Runtime-Leseverhalten)
+```mermaid
+sequenceDiagram
+    participant Consumer
+    participant Baseline as FileTypeProjectBaseline
+    participant Facade as FileTypeOptions
+    participant API as FileTypeDetector or other API
+
+    Consumer->>Baseline: ApplyDeterministicDefaults() (optional)
+    Baseline->>Facade: SetSnapshot(defaultProfile)
+
+    Consumer->>Facade: LoadOptions(json) (optional)
+    Facade->>Facade: Parse + Normalize + SetSnapshot
+
+    loop Jeder API-Call
+        Consumer->>API: Detect/Validate/Hash/Materialize
+        API->>Facade: GetSnapshot()
+        Facade-->>API: cloned normalized options
+        API-->>Consumer: Ergebnis mit aktivem Snapshot
+    end
+```
+
+## 5. Verbindliche Checklist und Done-Kriterien
+### 5.1 Implementierungs-Checklist
+- [ ] Option in `FileTypeProjectOptions` inkl. Default und Typ hinzugefuegt.
+- [ ] `NormalizeInPlace()` fuer fail-closed Grenzen aktualisiert.
+- [ ] `FileTypeOptions.LoadOptions(json)` parse path fuer neue Option erweitert.
+- [ ] `FileTypeOptions.GetOptions()` serialisiert die Option sichtbar.
+- [ ] Baseline-Entscheidung (`FileTypeProjectBaseline`) explizit getroffen.
+- [ ] Unit-Tests fuer parse/export/normalize hinzugefuegt oder angepasst.
+- [ ] Doku-Links in `docs/*` und ggf. `src/*/README.md` aktualisiert.
+
+### 5.2 Done-Kriterien
+Eine Optionsaenderung ist nur dann fertig, wenn:
+1. Werte deterministisch und fail-closed normalisiert werden.
+2. JSON-Load und JSON-Export konsistent sind.
+3. Baseline-Intent dokumentiert ist.
+4. Tests die Aenderung abdecken (Happy Path + Invalid Input).
+5. Markdown-Links gueltig sind.
+
+## 6. Verifikation (Kommandos)
+```bash
+python3 tools/check-markdown-links.py
+dotnet test tests/FileTypeDetectionLib.Tests/FileTypeDetectionLib.Tests.csproj --filter "FullyQualifiedName~FileTypeOptionsFacadeUnitTests|FullyQualifiedName~FileTypeProjectBaselineUnitTests" -v minimal
+```
+
+## 7. Typische Fehlerbilder und fail-closed Hinweise
+| Fehlerbild | Auswirkung | Gegenmassnahme |
+|---|---|---|
+| Property in `FileTypeProjectOptions`, aber kein Parse in `LoadOptions` | Option bleibt nie per JSON setzbar | parse case + Test ergaenzen |
+| Parse vorhanden, aber kein Export in `GetOptions` | Snapshot ist intransparent fuer Verwender | `GetOptions` + JsonDocument-Test ergaenzen |
+| Kein Normalize-Guard fuer numerische Grenzen | undefiniertes Runtime-Verhalten bei invalid values | `NormalizeInPlace` + invalid-value Tests |
+| Baseline-Wert vergessen | Produktionsprofil inkonsistent | `FileTypeProjectBaseline` + Baseline-Test updaten |
+| Nested-Objekt nur flach kopiert | Seiteneffekte/Lecks ueber Snapshots | `Clone`/`Normalize` fuer nested options absichern |
+
+## 8. Nicht-Ziele
+- Keine Aenderung der API-Semantik ohne begleitende Contract-Dokumentation.
+- Keine stillen Sicherheitslockerungen ohne expliziten Risikoentscheid.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,32 @@
+# Guides - Change Playbooks
+
+## 1. Zweck
+Diese Ebene unter `docs/guides/` liefert praxisnahe Playbooks fuer wiederkehrende Aenderungen:
+- Optionen neu anlegen oder anpassen
+- neue Datatypes/Modelle sauber ergaenzen
+
+Ziel ist, dass Entwickler und Verwender ohne Rueckfragen sehen:
+1. wo geaendert werden muss,
+2. wann die Aenderung aktiv wird,
+3. wie die Aenderung verifiziert wird.
+
+## 2. Playbooks
+1. [OPTIONS_CHANGE_GUIDE.md](./OPTIONS_CHANGE_GUIDE.md)
+2. [DATATYPE_EXTENSION_GUIDE.md](./DATATYPE_EXTENSION_GUIDE.md)
+
+## 3. Wann welcher Guide?
+| Frage | Guide |
+|---|---|
+| Neue oder geaenderte Konfigurationsoption? | `OPTIONS_CHANGE_GUIDE.md` |
+| Neuer erkennbarer Dateityp (`FileKind`) oder Magic/Alias-Update? | `DATATYPE_EXTENSION_GUIDE.md` |
+| Neues API-Rueckgabemodell unter `Abstractions/*`? | `DATATYPE_EXTENSION_GUIDE.md` |
+| Kombination aus Option + Datatype? | beide Guides, zuerst Options-Guide, dann Datatype-Guide |
+
+## 4. Verknuepfungen
+- [Doku-Index](../README.md)
+- [01 - Funktionen](../01_FUNCTIONS.md)
+- [02 - Gesamtarchitektur und Ablauffluesse](../02_ARCHITECTURE_AND_FLOWS.md)
+- [03 - Referenzen](../03_REFERENCES.md)
+
+## 5. Pflegehinweis
+Die Guides sind verbindliche Arbeitsvorlagen. Bei strukturellen API-Aenderungen muessen die betroffenen Abschnitte zeitgleich mitgepflegt werden.

--- a/src/FileTypeDetection/README.md
+++ b/src/FileTypeDetection/README.md
@@ -17,12 +17,16 @@ Deterministische Dateityp-Erkennung und sichere Archiv-Verarbeitung (u. a. fuer 
 11. [Abstractions/Detection-Details](./Abstractions/Detection/README.md)
 12. [Abstractions/Archive-Details](./Abstractions/Archive/README.md)
 13. [Abstractions/Hashing-Details](./Abstractions/Hashing/README.md)
+14. [Guides-Index](../../docs/guides/README.md)
+15. [Playbook: Options aendern](../../docs/guides/OPTIONS_CHANGE_GUIDE.md)
+16. [Playbook: Datatypes/Modelle erweitern](../../docs/guides/DATATYPE_EXTENSION_GUIDE.md)
 
 ## 2.1 Empfohlene Lesepfade
 - API-Nutzung zuerst: [docs/01_FUNCTIONS.md](../../docs/01_FUNCTIONS.md) -> [docs/02_ARCHITECTURE_AND_FLOWS.md](../../docs/02_ARCHITECTURE_AND_FLOWS.md) -> [docs/03_REFERENCES.md](../../docs/03_REFERENCES.md)
 - Implementierungsdetails zu Flows: [Detection/README.md](./Detection/README.md) + [Infrastructure/README.md](./Infrastructure/README.md)
 - Konfigurations- und Modellsicht: [Configuration/README.md](./Configuration/README.md) + [Abstractions/README.md](./Abstractions/README.md)
 - Modell-Drill-Down: [Abstractions/Detection/README.md](./Abstractions/Detection/README.md), [Abstractions/Archive/README.md](./Abstractions/Archive/README.md), [Abstractions/Hashing/README.md](./Abstractions/Hashing/README.md)
+- Aenderungs-Playbooks: [docs/guides/OPTIONS_CHANGE_GUIDE.md](../../docs/guides/OPTIONS_CHANGE_GUIDE.md) + [docs/guides/DATATYPE_EXTENSION_GUIDE.md](../../docs/guides/DATATYPE_EXTENSION_GUIDE.md)
 
 ## 2.2 API-Semantikhinweis (wichtig)
 - `TryValidateArchive(...)` und `ArchiveProcessing.*` sind die kanonischen Archiv-APIs.


### PR DESCRIPTION
Adds centralized developer guides under docs/guides for options changes and datatype/model extensions, plus index links in docs and module READMEs.