### PR TITLE
fix/versioning svt defaults

### DIFF
--- a/.github/workflows/version-policy.yml
+++ b/.github/workflows/version-policy.yml
@@ -11,9 +11,11 @@ jobs:
   version-policy:
     name: version-policy
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
       - name: Run versioning SVT (PR-safe)
         run: bash tools/ci/bin/run.sh versioning-svt


### PR DESCRIPTION
- **Fix versioning-svt defaults: use RepoVersion in consumer/test csproj**
- **Fix versioning-svt: match expected Condition whitespace**
- **Fix versioning-svt: tolerate whitespace in csproj Condition regex**
- **Fix versioning-svt: correct regex escaping for $(Prop) Condition**
- **feat(versioning): add version policy workflow for pull requests**
- **Fix CodeQL: restrict GITHUB_TOKEN permissions in version-policy workflow**
- **Fix CodeQL: move workflow permissions to top-level**
- **Fix version-policy workflow: restore triggers and keep top-level permissions**
- **Fix CodeQL: quote 'on' key so workflow permissions are recognized**
- **Fix CodeQL: quote 'on' key so workflow permissions are recognized v2-jobs-level-perm**
- **Fix CodeQL: canonical workflow permissions + indentation (version-policy)**
