### PR TITLE
ci(security): stabilize dependency-review scorecard noise handling

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,3 +21,5 @@ jobs:
           comment-summary-in-pr: on-failure
           fail-on-severity: moderate
           retry-on-snapshot-warnings: true
+          show-openssf-scorecard: false
+          warn-on-openssf-scorecard-level: 9

--- a/docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD
+++ b/docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD
@@ -37,3 +37,14 @@ Operational rule for this repo:
 - Keep Default Setup active for CodeQL until an explicit migration decision is made.
 - Do not run parallel advanced CodeQL workflow uploads in the same repository state.
 - Non-CodeQL SARIF uploads (for example OpenSSF Scorecard SARIF) are permitted.
+
+## 7. OpenSSF Scorecard Constraint for Third-Party GitHub Actions
+- Score values shown by `actions/dependency-review-action` for reused GitHub Actions are computed from the upstream action repositories (not from this repository).
+- This repository can pin SHAs and choose actions, but cannot directly increase upstream Scorecard values.
+- Operational handling:
+  - PR comments do not include the OpenSSF Scorecard table (`show-openssf-scorecard: false`).
+  - Warning threshold remains defined (`warn-on-openssf-scorecard-level: 9`) for machine-readable policy intent.
+- Repro command for upstream scores:
+```bash
+curl -fsSL "https://api.securityscorecards.dev/projects/github.com/actions/checkout" | jq -r '.date,.score,.repo.name'
+```

--- a/docs/audit/012_WAVE_EXECUTION_DOD.MD
+++ b/docs/audit/012_WAVE_EXECUTION_DOD.MD
@@ -42,6 +42,8 @@ Scope: Finalisierung aller offenen Security-/Governance-Punkte nach Wave-Plan.
 ## Snapshot Warning Hardening (Dependency Review)
 - DoD-SW.1: `dependency-review` verwendet `retry-on-snapshot-warnings: true`.
 - DoD-SW.2: PR-Kommentar-Output erfolgt nur bei Failure (`comment-summary-in-pr: on-failure`), damit Warnhinweise nicht als Dauerrauschen erscheinen.
+- DoD-SW.3: OpenSSF-Scorecard-Tabelle in PR-Kommentaren ist deaktiviert (`show-openssf-scorecard: false`), um nicht steuerbare Fremd-Repo-Scores nicht als Merge-Rauschen zu propagieren.
+- DoD-SW.4: Policy-Schwelle für Action-Score ist explizit gesetzt (`warn-on-openssf-scorecard-level: 9`) und im Workflow nachweisbar.
 
 ## Release Finalisierung
 - DoD-R.1: Nach Merge ist Tag `v5.1.0` erstellt und Release-Pipeline erfolgreich abgeschlossen.


### PR DESCRIPTION
## Summary
- disable OpenSSF scorecard table in dependency-review PR comments
- keep explicit policy threshold at 9 via workflow input
- document upstream score constraint and DoD evidence points

## Why
Upstream action repository scores are externally computed and not directly controllable from this repo. This change removes non-actionable comment noise while keeping security policy intent explicit and auditable.

## Evidence
- workflow input: `show-openssf-scorecard: false`
- workflow input: `warn-on-openssf-scorecard-level: 9`
- docs updated in audit roadmap and DoD matrix
