### PR TITLE
security(codeql): Advanced Setup fuer C# (build-mode manual)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Build (CodeQL traced)
         run: |
-          dotnet restore FileClassifier.sln
-          dotnet build -c Release --no-restore FileClassifier.sln
+          dotnet restore --locked-mode -v minimal FileClassifier.sln
+          dotnet build -c Release --no-restore -v minimal FileClassifier.sln
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3


### PR DESCRIPTION
## Ziel & Scope
Fixes #58: CodeQL fuer `language:csharp` soll nicht mehr mit `build-mode: none` laufen, sondern einen realen .NET-Build ausfuehren, damit die Extraktion/Analysequalitaet stabil ueber den Schwellenwerten liegt.

Non-Goals:
- Keine inhaltlichen Code-Aenderungen am Produktcode.
- Keine Aenderungen an `SECURITY.md`.

## Umgesetzte Aufgaben (abhaken)
- [x] Advanced CodeQL Workflow hinzugefuegt (`.github/workflows/codeql.yml`).
- [x] `build-mode: manual` konfiguriert (explizit, nicht `none`).
- [x] Traced Build via `dotnet restore` + `dotnet build -c Release` ueber `FileClassifier.sln` implementiert.
- [x] Actions/Dependencies SHA-gepinnt und least-privilege Permissions gesetzt.

## Nachbesserungen aus Review (iterativ)
- [ ] (falls Review Hinweise liefert) Workflow/Build-Schritte so anpassen, dass CodeQL-Extraktion vollstaendig ist.
- [ ] (falls Review Hinweise liefert) Query-Set/Category feinjustieren.

## Security- und Merge-Gates
- [x] Required Checks: alle required Checks in PR #61 sind gruen.
- [x] Code scanning: security/code-scanning/tools zeigt **0 offene Alerts**.
- [x] Keine Branch-Protection/Ruleset-Verletzungen.

## Evidence (auditierbar)
Lokal:
- `bash tools/ci/bin/run.sh preflight` -> `/Users/tomwerner/RiderProjects/FileClassifier/artifacts/ci/preflight/summary.md`
- `bash tools/ci/bin/run.sh build` -> `/Users/tomwerner/RiderProjects/FileClassifier/artifacts/ci/build/summary.md`
- `bash tools/ci/bin/run.sh tests-bdd-coverage` -> `/Users/tomwerner/RiderProjects/FileClassifier/artifacts/ci/tests-bdd-coverage/summary.md`

CI (PR #61):
- CodeQL Workflow Run: 22021055053 (Job: Analyze (csharp))
- CI Workflow Run (inkl. preflight/pr-governance): 22021055059

## DoD (mindestens 2 pro Punkt)
- Punkt: CodeQL Advanced Setup fuer C# (manual build)
- [x] DoD 1: Workflow ist least-privilege und SHA-gepinnt (auditierbar in `.github/workflows/codeql.yml`).
- [x] DoD 2: Lokale Build+Tests sind gruen (auditierbar in `artifacts/ci/build/summary.md` und `artifacts/ci/tests-bdd-coverage/summary.md`).
