### PR TITLE
ci(qodana): .editorconfig-Workaround entfernen

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -39,13 +39,6 @@ jobs:
         with:
           dotnet-version: "10.0.102"
 
-      - name: Temporarily disable .editorconfig for Qodana
-        shell: bash
-        run: |
-          if [ -f .editorconfig ]; then
-            mv .editorconfig .editorconfig.qodana.bak
-          fi
-
       - name: Run Qodana
         uses: JetBrains/qodana-action@42dad391966aca8ca344ca2340a7f43a5507e9b2 # v2025.3.1
         with:
@@ -54,14 +47,6 @@ jobs:
           results-dir: artifacts/ci/qodana
           upload-result: false
           use-caches: false
-
-      - name: Restore .editorconfig
-        if: always()
-        shell: bash
-        run: |
-          if [ -f .editorconfig.qodana.bak ]; then
-            mv .editorconfig.qodana.bak .editorconfig
-          fi
 
       - name: Run Entry Check
         if: always()


### PR DESCRIPTION
## Ziel & Scope
Fixes #59: Qodana soll mit der echten Repo-Konfiguration laufen. Der `.editorconfig`-Disable/Restore-Workaround in `.github/workflows/qodana.yml` wird entfernt.

Non-Goals:
- Keine inhaltlichen Regel-Aenderungen in `.editorconfig` (nur Workflow-Hack entfernen).
- Keine Aenderungen an `SECURITY.md`.

## Umgesetzte Aufgaben (abhaken)
- [x] Disable/Restore-Schritte fuer `.editorconfig` aus `.github/workflows/qodana.yml` entfernt.
- [x] Qodana laeuft damit gegen die reale Repo-Konfiguration (kein Datei-Rename).
- [x] Lokale CI-Skripte ausgefuehrt (preflight/build/tests) fuer Regressionschutz.

## Nachbesserungen aus Review (iterativ)
- [ ] Falls Qodana mit `.editorconfig` wieder fehlschlaegt: Root-Cause im Qodana-Log identifizieren und zielgerichtet beheben (konfig statt rename).
- [ ] Optional: `use-caches: true` separat evaluieren (nur wenn stabil, nicht in diesem PR).

## Security- und Merge-Gates
- [x] Required Checks: alle required Checks sind gruen.
- [x] Code scanning: security/code-scanning/tools zeigt **0 offene Alerts**.
- [x] Keine offenen Review-Threads (required conversation resolution).

## Evidence (auditierbar)
Lokal:
- `bash tools/ci/bin/run.sh preflight` -> `/Users/tomwerner/RiderProjects/FileClassifier/artifacts/ci/preflight/summary.md`
- `bash tools/ci/bin/run.sh build` -> `/Users/tomwerner/RiderProjects/FileClassifier/artifacts/ci/build/summary.md`
- `bash tools/ci/bin/run.sh tests-bdd-coverage` -> `/Users/tomwerner/RiderProjects/FileClassifier/artifacts/ci/tests-bdd-coverage/summary.md`

CI (PR #62):
- Qodana Workflow Run: 22021300257
- CI Workflow Run (inkl. preflight/pr-governance): 22021300238

## DoD (mindestens 2 pro Punkt)
- Punkt: Qodana ohne `.editorconfig`-Workaround
- [x] DoD 1: Workflow enthaelt keinen Datei-Hack mehr (auditierbar in `.github/workflows/qodana.yml`).
- [x] DoD 2: Lokale Build+Tests sind gruen (auditierbar in `artifacts/ci/build/summary.md` und `artifacts/ci/tests-bdd-coverage/summary.md`).
