### PR TITLE
docs(versioning): 5.1.3 und CodeQL Default-Setup in Docs nachziehen

### DIFF
--- a/docs/audit/000_INDEX.MD
+++ b/docs/audit/000_INDEX.MD
@@ -43,4 +43,4 @@ bash tools/versioning/verify-version-convergence.sh
 - OpenSSF Scorecard workflow: `.github/workflows/scorecard.yml`
 - Artifact attestations in release workflow: `.github/workflows/release.yml`
 - Deep analysis evidence workflow: `.github/workflows/code-analysis-evidence.yml`
-- GitHub Code Scanning Default Setup (configured): `gh api "repos/<owner>/<repo>/code-scanning/default-setup"`
+- GitHub Code Scanning Default Setup (state must be not-configured): `gh api "repos/<owner>/<repo>/code-scanning/default-setup"`

--- a/docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD
+++ b/docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD
@@ -36,11 +36,12 @@ gh attestation verify "$NUPKG" --repo tomtastisch/FileClassifier
 - Verification commands are documented and reproducible.
 
 ## 6. Code Scanning Mode Constraint
-This repository currently uses GitHub Code Scanning Default Setup (state: `configured`).
+This repository uses GitHub Code Scanning Advanced Setup (workflow-based CodeQL) and requires that GitHub Code Scanning
+Default Setup remains disabled (state: `not-configured`).
 When Default Setup is enabled, additional advanced CodeQL workflow uploads can be rejected by GitHub.
-Operational rule for this repo:
-- Keep Default Setup active for CodeQL until an explicit migration decision is made.
-- Do not run parallel advanced CodeQL workflow uploads in the same repository state.
+Operational rules for this repo:
+- Keep Default Setup disabled for CodeQL (see `docs/security/010_CODEQL_DEFAULT_SETUP_GUARDRAIL.MD`).
+- Treat Default-Setup drift as a fail-closed blocker and remediate before merging/releasing.
 - Non-CodeQL SARIF uploads (for example OpenSSF Scorecard SARIF) are permitted.
 
 ## 7. OpenSSF Scorecard Constraint for Third-Party GitHub Actions

--- a/docs/versioning/002_HISTORY_VERSIONS.MD
+++ b/docs/versioning/002_HISTORY_VERSIONS.MD
@@ -8,11 +8,11 @@ Heuristik fuer die Rueckwirkungs-Zuordnung:
 - `docs|test|ci|chore|tooling|refactor|fix` => Patch
 
 Aktueller Entwicklungsstand:
-- Aktuelle Entwicklungslinie enthaelt `5.x` (aktuell veroeffentlichtes Tag: `v5.1.2`; Details in `docs/versioning/003_CHANGELOG_RELEASES.MD`).
+- Aktuelle Entwicklungslinie enthaelt `5.x` (aktuell veroeffentlichtes Tag: `v5.1.3`; Details in `docs/versioning/003_CHANGELOG_RELEASES.MD`).
 
 | Version | Kurzbeschreibung | Commit | Keyword |
 |---|---|---|---|
-| `5.1.3` | PR-Governance-Haertung (DE-Naming, PR-Template, fail-closed Gate fuer `security/code-scanning/tools = 0`) | TBD (nach Merge) | patch |
+| `5.1.3` | PR-Governance-Haertung (DE-Naming, PR-Template, fail-closed Gate fuer `security/code-scanning/tools = 0`) | [0b488ac](https://github.com/tomtastisch/FileClassifier/commit/0b488ac) | patch |
 | `5.1.2` | Gate4 Polling-Optimierung und Release-Haertung | [f12711d](https://github.com/tomtastisch/FileClassifier/commit/f12711d) | patch |
 | `5.1.1` | Dependabot security-only mode und fail-closed Guards fuer secret-pflichtige Workflows | [d0ad8ec](https://github.com/tomtastisch/FileClassifier/commit/d0ad8ec) | patch |
 | `5.1.0` | Security/Governance hardening wave: pinned actions, dependency review, labeler fixes, root assurance index | [e2a4a42](https://github.com/tomtastisch/FileClassifier/commit/e2a4a42) | minor |


### PR DESCRIPTION
## Ziel & Scope
- Ziel: Docs auf den veroeffentlichten Stand bringen: Versionshistorie (`5.1.3`) und CodeQL Default-Setup Status (not-configured) konsistent dokumentieren.
- Scope: Nur Doku-Aenderungen in:
  - `docs/versioning/002_HISTORY_VERSIONS.MD`
  - `docs/audit/000_INDEX.MD`
  - `docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD`
- Non-Goals: Keine Produktcode- oder Workflow-Aenderungen, keine Aenderung an `SECURITY.md` (frozen).

## Umgesetzte Aufgaben (abhaken)
- [x] `docs/versioning/002_HISTORY_VERSIONS.MD`: "aktuell veroeffentlichtes Tag" von `v5.1.2` auf `v5.1.3` aktualisiert.
- [x] `docs/versioning/002_HISTORY_VERSIONS.MD`: `5.1.3` Commit von "TBD" auf den Tag-Commit `0b488ac` gesetzt.
- [x] `docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD`: Default-Setup Aussage korrigiert -> Default Setup muss `not-configured` bleiben.
- [x] `docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD`: Guardrail-Referenz ergaenzt (`docs/security/010_CODEQL_DEFAULT_SETUP_GUARDRAIL.MD`).
- [x] `docs/audit/000_INDEX.MD`: Default-Setup Hinweis korrigiert (state must be not-configured).
- [x] Keine inhaltlichen Aenderungen an Security-Claims; nur Konsistenz der Doku.
- [x] Keine Aenderung an `SECURITY.md`.
- [x] Diff klein und fokussiert (WIP=1).

## Nachbesserungen aus Review (iterativ)
- [ ] Keine (aktuell).

## Security- und Merge-Gates
- Merge-Gate: `security/code-scanning/tools` muss **`0 offene Alerts`** liefern (fail-closed).
- Merge nur, wenn required checks gruen sind und alle Review-Threads resolved sind (inkl. outdated).

## Evidence (auditierbar)
- Tag-Commit fuer `v5.1.3`: `git rev-parse 'v5.1.3^{}'` -> `0b488acf1f8563cf4dd19fcdf84f719987bd3cc5`
- Aenderungen:
  - `docs/versioning/002_HISTORY_VERSIONS.MD`
  - `docs/audit/000_INDEX.MD`
  - `docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD`

## DoD (mindestens 2 pro Punkt)
- Punkt: Versioning-History 5.1.3 finalisiert
- [x] `docs/versioning/002_HISTORY_VERSIONS.MD` referenziert `v5.1.3` als aktuell veroeffentlichtes Tag.
- [x] `docs/versioning/002_HISTORY_VERSIONS.MD` enthaelt fuer `5.1.3` einen konkreten Commit-Link (kein TBD).

- Punkt: Audit-Docs CodeQL Default Setup konsistent
- [x] `docs/audit/004_CERTIFICATION_AND_ATTESTATION_ROADMAP.MD` spiegelt Default-Setup `not-configured` und Advanced Setup korrekt.
- [x] `docs/audit/000_INDEX.MD` spiegelt Default-Setup `not-configured` korrekt.
