### PR TITLE
refactor(7c): Package C Exception-ReasonCodes normalisieren

### DIFF
--- a/docs/audit/006_CODE_REVIEW_FINDINGS.MD
+++ b/docs/audit/006_CODE_REVIEW_FINDINGS.MD
@@ -34,6 +34,10 @@ Evidence-backed candidates are tracked in:
 3. Dead-code candidate scan currently returned no low-reference source declarations in `src/` under the implemented heuristic.
    - Evidence: `artifacts/audit/dead_code_candidates.json`
 
+4. `DetectDetailed(...).ReasonCode` used a generic `"Exception"` bucket for distinct exception classes (IO, Security, Argument, etc.).
+   - Impact: reduced auditability of fail-closed paths (different root causes were indistinguishable in results).
+   - Status: Package C maps file-access exceptions to deterministic, typed reason codes.
+
 ## Repro Evidence Commands
 All commands are intended to run from the repository root.
 ```bash

--- a/src/FileTypeDetection/FileTypeDetector.vb
+++ b/src/FileTypeDetection/FileTypeDetector.vb
@@ -22,6 +22,12 @@ Namespace Global.Tomtastisch.FileClassifier
         Private Const ReasonInvalidLength As String = "InvalidLength"
         Private Const ReasonFileTooLarge As String = "FileTooLarge"
         Private Const ReasonException As String = "Exception"
+        Private Const ReasonExceptionUnauthorizedAccess As String = "ExceptionUnauthorizedAccess"
+        Private Const ReasonExceptionSecurity As String = "ExceptionSecurity"
+        Private Const ReasonExceptionIO As String = "ExceptionIO"
+        Private Const ReasonExceptionInvalidData As String = "ExceptionInvalidData"
+        Private Const ReasonExceptionNotSupported As String = "ExceptionNotSupported"
+        Private Const ReasonExceptionArgument As String = "ExceptionArgument"
         Private Const ReasonExtensionMismatch As String = "ExtensionMismatch"
         Private Const ReasonHeaderUnknown As String = "HeaderUnknown"
         Private Const ReasonHeaderMatch As String = "HeaderMatch"
@@ -602,8 +608,21 @@ Namespace Global.Tomtastisch.FileClassifier
         Private Shared Function LogDetectFailure(opt As FileTypeProjectOptions, ByRef trace As DetectionTrace,
                                                  ex As Exception) As FileType
             LogGuard.Error(opt.Logger, "[Detect] Ausnahme, fail-closed.", ex)
-            trace.ReasonCode = ReasonException
+            trace.ReasonCode = ExceptionToReasonCode(ex)
             Return UnknownType()
+        End Function
+
+        Private Shared Function ExceptionToReasonCode(ex As Exception) As String
+            If ex Is Nothing Then Return ReasonException
+
+            If TypeOf ex Is UnauthorizedAccessException Then Return ReasonExceptionUnauthorizedAccess
+            If TypeOf ex Is System.Security.SecurityException Then Return ReasonExceptionSecurity
+            If TypeOf ex Is IOException Then Return ReasonExceptionIO
+            If TypeOf ex Is InvalidDataException Then Return ReasonExceptionInvalidData
+            If TypeOf ex Is NotSupportedException Then Return ReasonExceptionNotSupported
+            If TypeOf ex Is ArgumentException Then Return ReasonExceptionArgument
+
+            Return ReasonException
         End Function
 
         Private Shared Function LogArchiveExtractFailure(opt As FileTypeProjectOptions, ex As Exception) As Boolean

--- a/tests/FileTypeDetectionLib.Tests/Unit/FileTypeDetectorEdgeUnitTests.cs
+++ b/tests/FileTypeDetectionLib.Tests/Unit/FileTypeDetectorEdgeUnitTests.cs
@@ -75,6 +75,21 @@ public sealed class FileTypeDetectorEdgeUnitTests
     }
 
     [Fact]
+    public void DetectDetailed_ReturnsExceptionIO_ForShareViolation()
+    {
+        using var scope = TestTempPaths.CreateScope("ftd-ex-io");
+        var path = Path.Combine(scope.RootPath, "locked.bin");
+        File.WriteAllBytes(path, new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D }); // "%PDF-" header prefix
+
+        using var locked = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var detail = new FileTypeDetector().DetectDetailed(path);
+
+        Assert.Equal(FileKind.Unknown, detail.DetectedType.Kind);
+        Assert.Equal("ExceptionIO", detail.ReasonCode);
+    }
+
+    [Fact]
     public void Detect_ReturnsUnknown_WhenPayloadExceedsMaxBytes()
     {
         using var optionsScope = new DetectorOptionsScope();


### PR DESCRIPTION
## Ziel & Scope
Package C (P3) aus Issue #67: Exception-to-Result Mapping fuer `DetectDetailed(...)` um deterministische ReasonCodes erweitern (statt generischem `"Exception"`).

Scope:
- `/Users/tomwerner/RiderProjects/FileClassifier/src/FileTypeDetection/FileTypeDetector.vb`
- `/Users/tomwerner/RiderProjects/FileClassifier/tests/FileTypeDetectionLib.Tests/Unit/FileTypeDetectorEdgeUnitTests.cs`
- `/Users/tomwerner/RiderProjects/FileClassifier/docs/audit/006_CODE_REVIEW_FINDINGS.MD`

Non-Goals:
- Keine Aenderung der Success-Paths
- Keine Aenderung oeffentlicher APIs

## Umgesetzte Aufgaben (abhaken)
- [x] Neue, deterministische Exception-ReasonCodes fuer `DetectDetailed(...)` eingefuehrt (`ExceptionIO`, `ExceptionSecurity`, ...)
- [x] Mapping-Funktion `ExceptionToReasonCode(...)` zentralisiert (SSOT)
- [x] `DetectPathCoreWithTrace`-Failure-Trace nutzt nun typisierte Exception-ReasonCodes statt `"Exception"`
- [x] Regression-Test: `DetectDetailed` liefert `ExceptionIO` bei Share-Violation (`FileTypeDetectorEdgeUnitTests`)
- [x] Lokaler Check: `dotnet build FileClassifier.sln -v minimal` (Exit 0)
- [x] Lokaler Check: `dotnet test ... -c Release -v minimal` (Exit 0)
- [x] Lokaler Check: `bash tools/audit/verify-code-analysis-evidence.sh` (Exit 0)
- [x] Findings aktualisiert (`docs/audit/006_CODE_REVIEW_FINDINGS.MD`)

## Nachbesserungen aus Review (iterativ)
- [ ] Derzeit keine Review-Nachbesserungen offen.

## Security- und Merge-Gates
- [x] Fail-closed bleibt erhalten (nur ReasonCode-Granularitaet in Failure-Trace; Success-Path unveraendert)
- [x] Required CI-Checks: muessen vor Merge gruen sein
- [x] Review-Threads: muessen vor Merge resolved sein
- [x] `security/code-scanning/tools`: 0 offene Alerts (Gate)

## Evidence (auditierbar)
Lokale Checks (Repo-Root):
```bash
dotnet build FileClassifier.sln -v minimal
```
```bash
dotnet test tests/FileTypeDetectionLib.Tests/FileTypeDetectionLib.Tests.csproj -c Release -v minimal
```
```bash
bash tools/audit/verify-code-analysis-evidence.sh
```

Code-Paths:
```bash
rg -n "ExceptionToReasonCode\(" src/FileTypeDetection/FileTypeDetector.vb
rg -n "ReasonExceptionIO|ReasonExceptionSecurity|ReasonExceptionUnauthorizedAccess" src/FileTypeDetection/FileTypeDetector.vb
```

Code Scanning Alerts (GitHub):
```bash
gh api -H "Accept: application/vnd.github+json" "/repos/tomtastisch/FileClassifier/code-scanning/alerts?state=open&per_page=100" --jq "length"  # => 0
```

## DoD (mindestens 2 pro Punkt)
- Punkt: deterministische Exception-ReasonCodes
  - Evidence: `/Users/tomwerner/RiderProjects/FileClassifier/src/FileTypeDetection/FileTypeDetector.vb`
  - Evidence: `dotnet test ... -c Release` (Tests gruen)
- Punkt: Regression-Test fuer IO-Exception Mapping
  - Evidence: `/Users/tomwerner/RiderProjects/FileClassifier/tests/FileTypeDetectionLib.Tests/Unit/FileTypeDetectorEdgeUnitTests.cs`
  - Evidence: `dotnet test ... -c Release` (Tests gruen)
