### PR TITLE
release(version): Version 5.1.4 veroeffentlichen

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
   <PropertyGroup>
-    <RepoVersion>5.1.3</RepoVersion>
+    <RepoVersion>5.1.4</RepoVersion>
   </PropertyGroup>
 </Project>

--- a/docs/versioning/002_HISTORY_VERSIONS.MD
+++ b/docs/versioning/002_HISTORY_VERSIONS.MD
@@ -8,10 +8,11 @@ Heuristik fuer die Rueckwirkungs-Zuordnung:
 - `docs|test|ci|chore|tooling|refactor|fix` => Patch
 
 Aktueller Entwicklungsstand:
-- Aktuelle Entwicklungslinie enthaelt `5.x` (aktuell veroeffentlichtes Tag: `v5.1.3`; Details in `docs/versioning/003_CHANGELOG_RELEASES.MD`).
+- Aktuelle Entwicklungslinie enthaelt `5.x` (aktuell veroeffentlichtes Tag: `v5.1.3`; naechstes vorgesehenes Tag: `v5.1.4`; Details in `docs/versioning/003_CHANGELOG_RELEASES.MD`).
 
 | Version | Kurzbeschreibung | Commit | Keyword |
 |---|---|---|---|
+| `5.1.4` | Refactor-Cluster 7C abgeschlossen + Qodana-Alerts auf 0 (Archive-Infrastructure Qualifier-Cleanup, Tests) | [0a85c82](https://github.com/tomtastisch/FileClassifier/commit/0a85c82) | patch |
 | `5.1.3` | PR-Governance-Haertung (DE-Naming, PR-Template, fail-closed Gate fuer `security/code-scanning/tools = 0`) | [0b488ac](https://github.com/tomtastisch/FileClassifier/commit/0b488ac) | patch |
 | `5.1.2` | Gate4 Polling-Optimierung und Release-Haertung | [f12711d](https://github.com/tomtastisch/FileClassifier/commit/f12711d) | patch |
 | `5.1.1` | Dependabot security-only mode und fail-closed Guards fuer secret-pflichtige Workflows | [d0ad8ec](https://github.com/tomtastisch/FileClassifier/commit/d0ad8ec) | patch |

--- a/docs/versioning/003_CHANGELOG_RELEASES.MD
+++ b/docs/versioning/003_CHANGELOG_RELEASES.MD
@@ -13,6 +13,15 @@ der Git-Tag `vX.Y.Z` (optional `-prerelease`) als SSOT.
 - Docs/CI/Tooling:
   - TBD
 
+## [5.1.4]
+- Changed:
+  - Cluster 7C: ReasonCodes/Exceptions konsolidiert und semantisch vereinheitlicht (DetectDetailed).
+  - Archive-Infrastructure: redundante `System.IO.*`-Qualifizierer bereinigt (Imports + unqualifiziert).
+- Fixed:
+  - Qodana Findings: `ConvertToConstant.Local` und `UseUtf8StringLiteral` in Tests beseitigt.
+- Docs/CI/Tooling:
+  - Code-Scanning-Zero-Gate fuer Qodana-Fix-PRs entkoppelt (PRs mit Label `area:qodana` pruefen PR-ref statt `main`).
+
 ## [5.1.3]
 - Added:
   - Verbindliches PR-Template in deutscher Sprache mit Checklisten, Nachbesserungs-Tracking und DoD-Matrix.

--- a/src/FileTypeDetection/FileTypeDetectionLib.vbproj
+++ b/src/FileTypeDetection/FileTypeDetectionLib.vbproj
@@ -7,8 +7,8 @@
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <PackageId>Tomtastisch.FileClassifier</PackageId>
-        <Version>5.1.3</Version>
-        <PackageVersion>5.1.3</PackageVersion>
+        <Version>5.1.4</Version>
+        <PackageVersion>5.1.4</PackageVersion>
         <Authors>tomtastisch</Authors>
         <Description>Deterministic file type and MIME detection with fail-closed archive safety checks, secure extraction primitives, and reproducible hashing evidence for .NET.</Description>
         <PackageTags>filetype;mime;detection;magic-bytes;sniffing;archive;zip;tar;7z;rar;zipslip;security;hashing;sha256;deterministic;dotnet;net8;net10</PackageTags>


### PR DESCRIPTION
## Ziel & Scope
- Version auf `5.1.4` anheben, damit die seit Release `v5.1.3` (2026-02-15) gemergten Aenderungen (u.a. #72-#75) sauber in einer neuen Release-Version veroeffentlicht werden koennen.
- Scope: nur Version/Docs (SSOT-Konvergenz) + Changelog; keine weiteren Codeaenderungen.

## Umgesetzte Aufgaben (abhaken)
- [x] `Directory.Build.props`: `RepoVersion` auf `5.1.4` gesetzt.
- [x] `src/FileTypeDetection/FileTypeDetectionLib.vbproj`: `Version`/`PackageVersion` auf `5.1.4` gesetzt.
- [x] `docs/versioning/002_HISTORY_VERSIONS.MD`: Top-Eintrag `5.1.4` hinzugefuegt.
- [x] `docs/versioning/003_CHANGELOG_RELEASES.MD`: Release-Notizen fuer `5.1.4` ergaenzt.
- [x] Repo-lokale Versionskonvergenz verifiziert (Repo/docs/vbproj).
- [x] Lokal: Build Release gruen.
- [x] Lokal: Tests Release gruen.

## Nachbesserungen aus Review (iterativ)
- [x] Keine Review-Nachbesserungen offen (Stand: PR-Erstellung).

## Security- und Merge-Gates
- [x] Required Checks: kein Bypass, Merge nur bei gruen.
- [x] security/code-scanning/tools: 0 offene Alerts (Status ist Gate fuer Merge/Release).
- [x] `SECURITY.md` nicht angefasst.

## Evidence (auditierbar)
- `bash tools/versioning/verify-version-convergence.sh` (remote_check=0)
- `dotnet build FileClassifier.sln -c Release`
- `dotnet test FileClassifier.sln -c Release` (413/413)

## DoD (mindestens 2 pro Punkt)
- [x] Version-SSOT Konvergenz (RepoVersion == vbproj Version/PackageVersion == Docs Top-Eintrag).
- [x] Build + Tests lokal Release gruen (Commands oben).
- [x] CI/Policies: PR-Governance + Versioning/Convergence Checks gruen.
- [x] Release-Follow-up nach Merge: Tag `v5.1.4` pushen und Release-Workflow erfolgreich verifizieren (inkl. NuGet).
