### PR TITLE
fix(versioning): prerelease-konvergenz fuer nuget-search stabilisieren

### DIFF
--- a/tools/ci/verify_nuget_release.sh
+++ b/tools/ci/verify_nuget_release.sh
@@ -176,9 +176,11 @@ PY
 }
 
 query_search() {
-  SEARCH_URL="https://azuresearch-usnc.nuget.org/query?q=packageid:${PKG_ID}&take=5"
+  # Always query with prerelease + SemVer2 enabled so RC versions are visible
+  # in the search index during convergence checks.
+  SEARCH_URL="https://azuresearch-usnc.nuget.org/query?q=packageid:${PKG_ID}&take=5&prerelease=true&semVerLevel=2.0.0"
   local response
-  response="$(curl -fsS --max-time "${TIMEOUT_SECONDS}" "${SEARCH_URL}")" || return 1
+  response="$(curl -fsS --compressed --max-time "${TIMEOUT_SECONDS}" "${SEARCH_URL}")" || return 1
 
   local out
   out="$(SEARCH_RESPONSE="${response}" python3 - "$PKG_ID" "$PKG_VER" <<'PY'
@@ -231,7 +233,7 @@ query_registration() {
   fi
 
   local response
-  response="$(curl -fsS --max-time "${TIMEOUT_SECONDS}" "${REGISTRATION_URL}")" || return 1
+  response="$(curl -fsS --compressed --max-time "${TIMEOUT_SECONDS}" "${REGISTRATION_URL}")" || return 1
 
   REGISTRATION_RESPONSE="${response}" python3 - "$PKG_VER" <<'PY' >/dev/null || return 1
 import json


### PR DESCRIPTION
## Ziel & Scope
Diese PR behebt einen deterministischen False-Negative-Fehler im NuGet-Online-Convergence-Check fuer Pre-Releases (`-rc.*`).

Scope:
- Search-Endpoint-Aufruf fuer NuGet-Konvergenz auf Pre-Release-/SemVer2-Sichtbarkeit korrigieren
- HTTP-Antwortverarbeitung fuer `registration5-gz-semver2` robust machen

Nicht im Scope:
- Paketinhalt/API-Aenderungen
- SECURITY.md
- Release-Policy-Aenderungen

## Umgesetzte Aufgaben (abhaken)
- [x] `tools/ci/verify_nuget_release.sh`: Search-Query um `prerelease=true&semVerLevel=2.0.0` erweitert
- [x] `tools/ci/verify_nuget_release.sh`: `curl` fuer Search/Registration auf `--compressed` gehaertet
- [x] Lokaler Nachweis mit `verify_nuget_release.sh` fuer `5.2.0-rc.5` erfolgreich
- [x] Lokaler Nachweis mit `verify_nuget_online_convergence.sh` fuer `5.2.0-rc.5` erfolgreich

## Nachbesserungen aus Review (iterativ)
- [x] Root-Cause dokumentiert: Search-Endpoint ohne Pre-Release-Flag liefert RC-Versionen nicht
- [x] Regression gegen bestehende Release-Pfade vermieden (ausschliesslich Query/Transport-Haertung)

## Security- und Merge-Gates
- [x] `security/code-scanning/tools`: 0 offene Alerts (Gate-Anforderung)
- [x] Required Checks werden vor Merge vollstaendig gruen abgewartet
- [x] Keine offenen Review-Threads vor Merge
- [x] Branch-Protection/Ruleset wird nicht umgangen

## Evidence (auditierbar)
Ausgefuehrt (lokal):
- `bash tools/ci/release/verify_nuget_online_convergence.sh "5.2.0-rc.5" "artifacts/ci/nuget-online-convergence/verify-local.log" "Tomtastisch.FileClassifier"`
- `PKG_ID='Tomtastisch.FileClassifier' PKG_VER='5.2.0-rc.5' EXPECTED_VERSION='5.2.0-rc.5' RETRY_COUNT=0 VERIFY_ONLINE=1 REQUIRE_SEARCH=1 REQUIRE_REGISTRATION=1 REQUIRE_FLATCONTAINER=1 bash tools/ci/verify_nuget_release.sh`
- `curl -fsSL "https://azuresearch-usnc.nuget.org/query?q=packageid:Tomtastisch.FileClassifier&take=5"`
- `curl -fsSL "https://azuresearch-usnc.nuget.org/query?q=packageid:Tomtastisch.FileClassifier&take=5&prerelease=true&semVerLevel=2.0.0"`

Erwartung/Nachweis:
- Ohne Pre-Release-Flags fehlt `5.2.0-rc.5` im Search-Ergebnis
- Mit Pre-Release-Flags ist `5.2.0-rc.5` sichtbar und Konvergenz-Check erfolgreich

## DoD (mindestens 2 pro Punkt)
| Umgesetzter Punkt | DoD 1 (auditierbar) | DoD 2 (auditierbar) |
|---|---|---|
| Pre-Release-Sichtbarkeit im Search-Check | `verify_nuget_release.sh` liefert `search: ok` fuer `5.2.0-rc.5` | Search-Query mit `prerelease=true&semVerLevel=2.0.0` enthaelt `5.2.0-rc.5` |
| Robustheit Registration-Check | `registration_check: ok` mit `registration5-gz-semver2` | `verify_nuget_online_convergence.sh` endet lokal erfolgreich |
| CI-Konvergenz-Fehlerursache beseitigt | Root-Cause reproduziert und in PR-Evidence festgehalten | Nur zielgerichtete Aenderung an `tools/ci/verify_nuget_release.sh` |
