### PR TITLE
ci(workflows): codeql-action auf v4-sha migrieren

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
           dotnet-version: "10.0.102"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3
+        uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
         with:
           languages: ${{ matrix.language }}
           build-mode: manual
@@ -62,6 +62,6 @@ jobs:
           dotnet build -c Release --no-restore -v minimal FileClassifier.sln
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3
+        uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload SARIF To Code Scanning
         if: github.event_name != 'pull_request'
-        uses: github/codeql-action/upload-sarif@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3
+        uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
         with:
           sarif_file: artifacts/ci/qodana/qodana.sarif.json
 


### PR DESCRIPTION
## Ziel & Scope
Migration der in CI verwendeten `github/codeql-action` Referenzen von v3 auf v4 als SHA-Pin, um die bekannte Deprecation-Warnung zu beseitigen und den Security-/Maintenance-Stand production-ready zu halten.
Scope ist auf Workflow-Dateien begrenzt; keine Runtime-, API- oder Paket-Semantik-Aenderung im Produktcode.

## Umgesetzte Aufgaben (abhaken)
- [x] `github/codeql-action/init` in `/Users/tomwerner/RiderProjects/FileClassifier/.github/workflows/codeql.yml` auf v4-SHA aktualisiert.
- [x] `github/codeql-action/analyze` in `/Users/tomwerner/RiderProjects/FileClassifier/.github/workflows/codeql.yml` auf v4-SHA aktualisiert.
- [x] `github/codeql-action/upload-sarif` in `/Users/tomwerner/RiderProjects/FileClassifier/.github/workflows/qodana.yml` auf v4-SHA aktualisiert.
- [x] Alle geaenderten Action-Referenzen bleiben SHA-gepinnt (kein Tag/Floating-Ref).
- [x] Pin-Quelle fuer v4 verifiziert (`github/codeql-action` Tag-Referenz auf Commit aufgeloest).
- [x] Lokale Workflow-Syntaxpruefung via `actionlint` ausgefuehrt.
- [x] Offene GitHub Security-Signale geprueft (`code-scanning`, `dependabot`, `secret-scanning`).
- [x] Branch-/PR-Schema gemaess Governance eingehalten.

## Nachbesserungen aus Review (iterativ)
- [x] Keine Review-Nachbesserungen offen (initiale PR-Fassung bereits auf Governance-Template ausgerichtet).
- [x] Formulierungen und Scope strikt auf CI-Workflow-Migration begrenzt.

## Security- und Merge-Gates
- [x] `security/code-scanning/tools`: 0 offene Alerts (Merge-Bedingung)
- [x] `dependabot alerts`: 0 offen
- [x] `secret-scanning alerts`: 0 offen
- [x] Keine Aenderung an `/Users/tomwerner/RiderProjects/FileClassifier/SECURITY.md`
- [x] Required Checks muessen vor Merge gruen sein
- [x] Keine offenen Review-Threads vor Merge

## Evidence (auditierbar)
- Geaenderte Dateien:
  - `/Users/tomwerner/RiderProjects/FileClassifier/.github/workflows/codeql.yml`
  - `/Users/tomwerner/RiderProjects/FileClassifier/.github/workflows/qodana.yml`
- Ausgefuehrte Kommandos (lokal):
  - `gh api repos/github/codeql-action/git/ref/tags/v4 | jq -r '.object.type+" "+.object.sha'`
  - `gh api repos/github/codeql-action/git/tags/<tag-sha> | jq -r '.object.type+" "+.object.sha'`
  - `actionlint .github/workflows/*.yml`
  - `gh api "repos/tomtastisch/FileClassifier/code-scanning/alerts?state=open&per_page=100" | jq 'length'` -> `0`
  - `gh api "repos/tomtastisch/FileClassifier/dependabot/alerts?state=open&per_page=100" | jq 'length'` -> `0`
  - `gh api "repos/tomtastisch/FileClassifier/secret-scanning/alerts?state=open&per_page=100" | jq 'length'` -> `0`
- Verwendeter v4-SHA:
  - `9e907b5e64f6b83e7804b09294d44122997950d6` (`github/codeql-action`)

## DoD (mindestens 2 pro Punkt)
| Punkt | DoD-1 | DoD-2 |
|---|---|---|
| CodeQL Workflow-Migration | Alle 3 `github/codeql-action` Verwendungen zeigen auf v4-SHA | Keine v3-Referenz mehr in `.github/workflows/` vorhanden |
| Security-/Governance-Stand | `code-scanning`/`dependabot`/`secret-scanning` offen jeweils `0` | SHA-Pinning in den geaenderten Workflows bleibt erhalten |
| Merge-Readiness | PR-Template mit Pflichtsektionen und Checklisten vorhanden | Required Checks sind gruen und Threads sind resolved |
