### PR TITLE
docs(readme): stabile release-linie 5.2.0 klarstellen

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ EXPECTED_VERSION=X.Y.Z bash tools/ci/verify_nuget_release.sh
 ## 5. Compatibility / TFMs
 - Library-Zielplattformen: `netstandard2.0`, `net8.0` und `net10.0`
 - Release-Versioning: Git-Tag `vX.Y.Z` (optional `-prerelease`) ist SSOT
-- Aktueller Pre-Release-Kanal der `5.2.0`-Linie: `v5.2.0-rc.6`
+- Aktueller stabiler Release-Tag: `v5.2.0`
 
 ## 6. Architekturüberblick
 ### 6.1 Kernklassen (Datenfluss)


### PR DESCRIPTION
## Ziel & Scope
- Verbleibende Release-Dokumentationsdrift nach Stable-Promotion schließen.
- `README.md` auf den tatsächlichen Stable-Stand `v5.2.0` ausrichten.
- Keine Code- oder API-Änderung, nur dokumentarische Konvergenz.

## Umgesetzte Aufgaben (abhaken)
- [x] `README.md` Abschnitt "Compatibility / TFMs" geprüft.
- [x] Veralteten RC6-Hinweis entfernt.
- [x] Stable-Release-Hinweis auf `v5.2.0` gesetzt.
- [x] Suchlauf auf verbleibende RC6-Referenz im README durchgeführt.
- [x] `check-doc-consistency.py` lokal ausgeführt.
- [x] `check-docs.py` lokal ausgeführt.
- [x] Änderung auf separatem `codex/docs/*` Branch isoliert.
- [x] Keine Änderung an Produktcode, Security- oder Build-Konfiguration.

## Nachbesserungen aus Review (iterativ)
- [x] Verbleibenden Open-Point „RC6-Hinweis in README“ als konkrete Drift klassifiziert.
- [x] Scope auf minimal-invasive 1-Zeilen-Anpassung begrenzt.

## Security- und Merge-Gates
- [x] Kein Secret-Wert geändert oder geloggt.
- [x] Kein Workflow-Bypass, kein Gate deaktiviert.
- [x] Merge nur bei grünen Required Checks.
- [x] `security/code-scanning/tools` bleibt Merge-Gate mit `0 offene Alerts`.

## Evidence (auditierbar)
1. Diff
- `git diff -- README.md`
- Ergebnis: 1 Zeile ersetzt (`rc6` -> `v5.2.0`).

2. Doku-Gates
- `python3 tools/check-doc-consistency.py` -> `Doc consistency check OK`
- `python3 tools/check-docs.py` -> `Doc check OK`

3. Drift-Suche
- `rg -n "Aktueller Pre-Release-Kanal|v5.2.0-rc.6" README.md` -> keine Treffer

## DoD (mindestens 2 pro Punkt)
| Punkt | DoD A | DoD B |
|---|---|---|
| README-Konvergenz | Kein RC6-Hinweis mehr im Compatibility-Abschnitt | Stabiler Tag `v5.2.0` explizit ausgewiesen |
| Gate-Konformität | Doku-Konsistenzcheck ist `OK` | Doku-Linkcheck ist `OK` |
