### PR TITLE
fix(ci): preflight-main race mit qodana-run synchronisieren

### DIFF
--- a/tools/versioning/compute-pr-labels.js
+++ b/tools/versioning/compute-pr-labels.js
@@ -22,6 +22,7 @@ const AREA_RULES = [
   { exact: 'qodana.yaml', label: 'area:qodana' },
   { exact: '.github/workflows/qodana.yml', label: 'area:qodana' },
   { exact: 'tools/ci/check-code-scanning-tools-zero.sh', label: 'area:qodana' },
+  { exact: 'tools/versioning/compute-pr-labels.js', label: 'area:qodana' },
   { prefix: 'src/FileTypeDetection/Infrastructure/Archive', label: 'area:archive' },
   { prefix: 'src/FileTypeDetection/ArchiveProcessing', label: 'area:archive' },
   { exact: 'src/FileTypeDetection/EvidenceHashing.vb', label: 'area:hashing' },


### PR DESCRIPTION
## Ziel & Scope
- Ziel: Race zwischen `preflight` und `qodana` auf `main` beseitigen, damit `code-scanning-tools-zero` nicht vor SARIF-Upload false-negative/fail liefert.
- Scope: Nur `tools/ci/check-code-scanning-tools-zero.sh`.

## Umgesetzte Aufgaben (abhaken)
- [x] Auf `push` nach `main` wartet der Check jetzt deterministisch auf den `qodana`-Run fuer denselben `GITHUB_SHA`.
- [x] Fail-closed Verhalten eingefuehrt: API-/Status-Fehler oder nicht-successful qodana conclusion brechen mit klarer Fehlursache ab.
- [x] Danach erst Query auf offene Code-Scanning-Alerts.

## Nachbesserungen aus Review (iterativ)
- [x] N/A (keine neuen Reviews beim Erstellen).

## Security- und Merge-Gates
- [x] Kein Gate-Bypass: bei qodana-Fehler bleibt `preflight` fail.
- [x] Race-bedingte False-Fails auf `main` werden vermieden.
- [x] Zielzustand bleibt: `security/code-scanning/tools` und `0 offene Alerts` fuer policy-relevante Findings.

## Evidence (auditierbar)
- `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main GITHUB_SHA=29ad98731bcd941b7ec9709bccaae4ed3b4993ab GITHUB_REPOSITORY=tomtastisch/FileClassifier ./tools/ci/check-code-scanning-tools-zero.sh`
- `jq -r '.status+" | "+(.open_alerts|tostring)' artifacts/ci/preflight/code-scanning-tools-zero/result.json` => `pass | 0`
- Vorheriger Main-Fail-Artefaktbeleg: `gh run download 22186363050 -n ci-preflight ...` mit `Offene Code-Scanning-Alerts vorhanden (66)`.

## DoD (mindestens 2 pro Punkt)
- Punkt A: Race-Synchronisierung
  - DoD1: Script erkennt fuer `main` den qodana-Run anhand `head_sha`.
  - DoD2: Alert-Query startet erst nach erfolgreichem qodana-Abschluss.
- Punkt B: Fail-closed Robustheit
  - DoD1: API-/Timeout-/Nicht-success-Zustaende fuehren explizit zu `fail`.
  - DoD2: Logging enthaelt eindeutige Ursache inkl. Run-URL.

- [x] Timeoutfenster fuer qodana-Synchronisierung auf 20 Minuten erweitert (Queue-/Lastspitzen fail-closed abgedeckt).
- [x] Label-Mapping erweitert: Aenderungen an `tools/ci/check-code-scanning-tools-zero.sh` setzen `area:qodana`.
